### PR TITLE
Fix AimBonus being assigned as crit chance modifier

### DIFF
--- a/JediClassRevised/Src/JediClassRevised/Classes/X2Item_WeaponUpgrade_Lightsaber.uc
+++ b/JediClassRevised/Src/JediClassRevised/Classes/X2Item_WeaponUpgrade_Lightsaber.uc
@@ -65,7 +65,7 @@ static function X2DataTemplate CreateJediUpgrade(name SocketName, UpgradeSetup T
 	
 	if (ThisUpgradeSetup.CritChanceBonus > 0)
 	{
-		Template.CritBonus = ThisUpgradeSetup.AimBonus;
+		Template.CritBonus = ThisUpgradeSetup.CritChanceBonus;
 		Template.AddCritChanceModifierFn = CritUpgradeModifier;
 	}
 


### PR DESCRIPTION
Properly sets CritChanceBonus as the crit chance modifier